### PR TITLE
Reduce log level on first attempt (issue #6)

### DIFF
--- a/redo/__init__.py
+++ b/redo/__init__.py
@@ -135,8 +135,9 @@ def retry(action, attempts=5, sleeptime=60, max_sleeptime=5 * 60,
                      max_sleeptime=max_sleeptime, sleepscale=sleepscale,
                      jitter=jitter):
         try:
-            log.info("retry: Calling %s with args: %s, kwargs: %s, "
-                     "attempt #%d" % (action, str(args), str(kwargs), n))
+            logfn = log.info if n != 1 else log.debug
+            logfn("retry: Calling %s with args: %s, kwargs: %s, "
+                  "attempt #%d" % (action, str(args), str(kwargs), n))
             return action(*args, **kwargs)
         except retry_exceptions:
             log.debug("retry: Caught exception: ", exc_info=True)


### PR DESCRIPTION
Avoid polluting the log with too much messages when all goes well, by
reducing the log level of the first attempt announcement to debug, rather
than info.