### PR TITLE
Fix .taskclusterrc file to follow new format

### DIFF
--- a/.taskclusterrc
+++ b/.taskclusterrc
@@ -1,17 +1,17 @@
 ---
 version: 1
 tasks:
-  payload:
+  - payload:
     image: "ubuntu:latest"
     command:
       - "/bin/bash"
       - "-c"
       - "./runtests.sh"
-extra:
-  github_events:
-    - pull_request.*
-  whitelist:
-    orgs:
-      - mozilla
-      - bhearsum
-    users: []
+  extra:
+    github_events:
+      - pull_request.*
+    whitelist:
+      orgs:
+        - mozilla
+        - bhearsum
+      users: []

--- a/.taskclusterrc
+++ b/.taskclusterrc
@@ -7,3 +7,11 @@ tasks:
       - "/bin/bash"
       - "-c"
       - "./runtests.sh"
+extra:
+  github_events:
+    - pull_request.*
+  whitelist:
+    orgs:
+      - mozilla
+      - bhearsum
+    users: []


### PR DESCRIPTION
This fixes the format and allows any public member of the Mozilla organization to trigger jobs.