### PR TITLE
tox doesn't run test_retry.py

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -13,7 +13,7 @@ tasks:
       command:
         - "/bin/bash"
         - "-c"
-        - "git clone {{ event.head.repo.url }} && cd redo && git checkout {{ event.head.repo.branch }} && tox -e py27"
+        - "git clone {{ event.head.repo.url }} && cd redo && git checkout {{ event.head.repo.branch }} && tox"
     extra:
       github:
         env: true

--- a/redo/__init__.py
+++ b/redo/__init__.py
@@ -56,6 +56,7 @@ def retrier(attempts=5, sleeptime=10, max_sleeptime=300, sleepscale=1.5, jitter=
         ...     print("max tries hit")
         max tries hit
     """
+    jitter = jitter or 0  # py35 barfs on the next line if jitter is None
     if jitter > sleeptime:
         # To prevent negative sleep times
         raise Exception('jitter ({}) must be less than sleep time ({})'.format(jitter, sleeptime))

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,18 @@
 [tox]
-envlist = py27,pypy,py34
+envlist = py27,pypy,py34,py35
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
     flake8
+    mock
     pytest
     pytest-cov
 
 commands=
     flake8 redo
-    py.test -v --cov=redo --cov-report term-missing --doctest-modules redo
+    py.test -v --cov=redo --cov-report term-missing --doctest-modules redo test_retry.py
 
 [testenv:py27-coveralls]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
 
 commands=
     flake8 redo
-    py.test --cov=redo --cov-report term-missing --doctest-modules redo
+    py.test -v --cov=redo --cov-report term-missing --doctest-modules redo
 
 [testenv:py27-coveralls]
 deps=


### PR DESCRIPTION
And when it does, it's missing `mock` and barfs on the `if jitter > sleeptime` when `jitter` is `None`.
Hoping the taskcluster docker instance has py34 and py35 on it, otherwise the final commit might need to be altered.